### PR TITLE
Dev

### DIFF
--- a/src/main/java/net/manufloso/item/ModCreativeModeTabs.java
+++ b/src/main/java/net/manufloso/item/ModCreativeModeTabs.java
@@ -27,7 +27,6 @@ public class ModCreativeModeTabs
                         output.accept(ModItems.ENDIUM_SWORD);
                         output.accept(ModItems.ENDIUM_PICKAXE);
                         output.accept(ModItems.ENDIUM_AXE);
-                        output.accept(ModItems.STACKOVER_AXE);
                         output.accept(ModItems.ENDIUM_SHOVEL);
                         output.accept(ModItems.ENDIUM_HOE);
                         output.accept(ModItems.ENDIUM_HELMET);
@@ -44,6 +43,10 @@ public class ModCreativeModeTabs
                         output.accept(ModItems.LARGE_NETHERITE_SHOVEL);
                         output.accept(ModItems.LARGE_DIAMOND_SHOVEL);
                         output.accept(ModItems.LARGE_IRON_SHOVEL);
+                        output.accept(ModItems.IRON_STAXEOVERFLOW);
+                        output.accept(ModItems.DIAMOND_STAXEOVERFLOW);
+                        output.accept(ModItems.NETHERITE_STAXEOVERFLOW);
+                        output.accept(ModItems.ENDIUM_STAXEOVERFLOW);
                         output.accept(ModItems.LAUNCHER);
                         output.accept(ModItems.SLINGSHOT);
                         output.accept(ModItems.SLIME_BOOTS);

--- a/src/main/java/net/manufloso/item/ModItems.java
+++ b/src/main/java/net/manufloso/item/ModItems.java
@@ -66,16 +66,16 @@ public class ModItems
 
     public static final DeferredItem<LargeShovelItem> LARGE_ENDIUM_SHOVEL = ITEMS.register("large_endium_shovel",
             () -> new LargeShovelItem(ModToolTiers.ENDIUM, new Item.Properties()
-                    .attributes(PickaxeItem.createAttributes(ModToolTiers.ENDIUM, 20F, -3.5f))));
+                    .attributes(ShovelItem.createAttributes(ModToolTiers.ENDIUM, 20F, -3.5f))));
     public static final DeferredItem<LargeShovelItem> LARGE_NETHERITE_SHOVEL = ITEMS.register("large_netherite_shovel",
             () -> new LargeShovelItem(Tiers.NETHERITE, new Item.Properties()
-                    .attributes(PickaxeItem.createAttributes(Tiers.NETHERITE, 8F, -3.5f))));
+                    .attributes(ShovelItem.createAttributes(Tiers.NETHERITE, 8F, -3.5f))));
     public static final DeferredItem<LargeShovelItem> LARGE_DIAMOND_SHOVEL = ITEMS.register("large_diamond_shovel",
             () -> new LargeShovelItem(Tiers.DIAMOND, new Item.Properties()
-                    .attributes(PickaxeItem.createAttributes(Tiers.DIAMOND, 6F, -3.5f))));
+                    .attributes(ShovelItem.createAttributes(Tiers.DIAMOND, 6F, -3.5f))));
     public static final DeferredItem<LargeShovelItem> LARGE_IRON_SHOVEL = ITEMS.register("large_iron_shovel",
             () -> new LargeShovelItem(Tiers.IRON, new Item.Properties()
-                    .attributes(PickaxeItem.createAttributes(Tiers.IRON, 4F, -3.5f))));
+                    .attributes(ShovelItem.createAttributes(Tiers.IRON, 4F, -3.5f))));
 
 
     public static final DeferredItem<ArmorItem> ENDIUM_HELMET = ITEMS.register("endium_helmet",
@@ -152,8 +152,21 @@ public class ModItems
     );
 
 
-    public static final DeferredItem<StackoverAXE> STACKOVER_AXE = ITEMS.register("stackover_axe",
-            () -> new StackoverAXE(ModToolTiers.ENDIUM, new Item.Properties()));
+    public static final DeferredItem<StAXEoverflow> IRON_STAXEOVERFLOW = ITEMS.register("iron_staxeoverflow",
+            () -> new StAXEoverflow(Tiers.IRON, new Item.Properties()
+                    .attributes(AxeItem.createAttributes(Tiers.IRON, 8F, -3.5f))));
+
+    public static final DeferredItem<StAXEoverflow> DIAMOND_STAXEOVERFLOW = ITEMS.register("diamond_staxeoverflow",
+            () -> new StAXEoverflow(Tiers.DIAMOND, new Item.Properties()
+                    .attributes(AxeItem.createAttributes(Tiers.DIAMOND, 12F, -3.5f))));
+
+    public static final DeferredItem<StAXEoverflow> NETHERITE_STAXEOVERFLOW = ITEMS.register("netherite_staxeoverflow",
+            () -> new StAXEoverflow(Tiers.NETHERITE, new Item.Properties()
+                    .attributes(AxeItem.createAttributes(Tiers.NETHERITE, 18F, -3.0f))));
+
+    public static final DeferredItem<StAXEoverflow> ENDIUM_STAXEOVERFLOW = ITEMS.register("endium_staxeoverflow",
+            () -> new StAXEoverflow(ModToolTiers.ENDIUM, new Item.Properties()
+                    .attributes(AxeItem.createAttributes(ModToolTiers.ENDIUM, 400F, -2.5f))));
 
 
 

--- a/src/main/java/net/manufloso/item/custom/StAXEoverflow.java
+++ b/src/main/java/net/manufloso/item/custom/StAXEoverflow.java
@@ -13,8 +13,8 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.*;
 
-public class StackoverAXE extends AxeItem {
-    public StackoverAXE(Tier tier, Properties properties) {
+public class StAXEoverflow extends AxeItem {
+    public StAXEoverflow(Tier tier, Properties properties) {
         super(tier, properties);
     }
 
@@ -35,7 +35,7 @@ public class StackoverAXE extends AxeItem {
         visited.add(startPos);
 
         int brokenBlocks = 0;
-        int limit = 2048;
+        int limit = 128;
 
         while (!queue.isEmpty() && brokenBlocks < limit) {
 
@@ -54,7 +54,7 @@ public class StackoverAXE extends AxeItem {
                         }
 
                         BlockState neighborState = level.getBlockState(neighborPos);
-                        if (neighborState.is(BlockTags.LOGS) || neighborState.is(BlockTags.LEAVES)) {
+                        if (neighborState.is(BlockTags.LOGS)) {
                             visited.add(neighborPos);
                             if (level.destroyBlock(neighborPos, true, player)) {
                                 stack.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);

--- a/src/main/resources/assets/supermodreborn/lang/en_us.json
+++ b/src/main/resources/assets/supermodreborn/lang/en_us.json
@@ -161,6 +161,10 @@
   "item.supermodreborn.pizza_base": "Pizza Base",
   "item.supermodreborn.raw_pizza": "Raw Pizza",
   "item.supermodreborn.pizza": "Pizza",
+  "item.supermodreborn.iron_staxeoverflow": "Iron Staxeoverflow",
+  "item.supermodreborn.diamond_staxeoverflow": "Diamond Staxeoverflow",
+  "item.supermodreborn.netherite_staxeoverflow": "Netherite Staxeoverflow",
+  "item.supermodreborn.endium_staxeoverflow": "Endium Staxeoverflow",
 
   "tooltip.supermodreborn.chunk_loader": "Place this block to keep this chunk loaded",
   "tooltip.supermodreborn.launcher": "Right click on the ground to fly",

--- a/src/main/resources/assets/supermodreborn/models/item/diamond_staxeoverflow.json
+++ b/src/main/resources/assets/supermodreborn/models/item/diamond_staxeoverflow.json
@@ -1,0 +1,88 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+      "0": "minecraft:block/oak_log",
+      "1": "minecraft:block/diamond_block",
+      "particle": "minecraft:block/diamond_block"
+	},
+	"elements": [
+		{
+			"from": [7, 0, 7],
+			"to": [9, 16, 9],
+			"faces": {
+				"north": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"down": {"uv": [0.032, 0.032, 1.968, 1.968], "texture": "#0", "cullface": "down"}
+			}
+		},
+		{
+			"from": [5, 16, 6],
+			"to": [9, 23, 10],
+			"rotation": {"angle": 0, "axis": "y", "origin": [7, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		},
+		{
+			"from": [3, 16, 5],
+			"to": [5, 23, 11],
+			"rotation": {"angle": 0, "axis": "y", "origin": [3, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		},
+		{
+			"from": [9, 16, 7],
+			"to": [13, 23, 9],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, 90, 0],
+			"translation": [0, 5.25, 1.25]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, 90, 0],
+			"translation": [0, 5.25, 1.25]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, 90, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, 90, 0]
+		},
+		"ground": {
+			"rotation": [90, 0, 77]
+		},
+		"gui": {
+			"rotation": [10, -35, 45],
+			"translation": [2, -3, 0],
+			"scale": [0.7, 0.7, 0.7]
+		},
+		"head": {
+			"translation": [0, 12.25, 0]
+		},
+		"fixed": {
+			"translation": [0, -3.25, 0]
+		}
+	}
+}

--- a/src/main/resources/assets/supermodreborn/models/item/endium_staxeoverflow.json
+++ b/src/main/resources/assets/supermodreborn/models/item/endium_staxeoverflow.json
@@ -1,0 +1,88 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+      "0": "minecraft:block/oak_log",
+      "1": "supermodreborn:block/endium_block",
+      "particle": "supermodreborn:block/endium_block"
+	},
+	"elements": [
+		{
+			"from": [7, 0, 7],
+			"to": [9, 16, 9],
+			"faces": {
+				"north": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"down": {"uv": [0.032, 0.032, 1.968, 1.968], "texture": "#0", "cullface": "down"}
+			}
+		},
+		{
+			"from": [5, 16, 6],
+			"to": [9, 23, 10],
+			"rotation": {"angle": 0, "axis": "y", "origin": [7, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		},
+		{
+			"from": [3, 16, 5],
+			"to": [5, 23, 11],
+			"rotation": {"angle": 0, "axis": "y", "origin": [3, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		},
+		{
+			"from": [9, 16, 7],
+			"to": [13, 23, 9],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, 90, 0],
+			"translation": [0, 5.25, 1.25]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, 90, 0],
+			"translation": [0, 5.25, 1.25]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, 90, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, 90, 0]
+		},
+		"ground": {
+			"rotation": [90, 0, 77]
+		},
+		"gui": {
+			"rotation": [10, -35, 45],
+			"translation": [2, -3, 0],
+			"scale": [0.7, 0.7, 0.7]
+		},
+		"head": {
+			"translation": [0, 12.25, 0]
+		},
+		"fixed": {
+			"translation": [0, -3.25, 0]
+		}
+	}
+}

--- a/src/main/resources/assets/supermodreborn/models/item/iron_staxeoverflow.json
+++ b/src/main/resources/assets/supermodreborn/models/item/iron_staxeoverflow.json
@@ -1,0 +1,88 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+      "0": "minecraft:block/oak_log",
+      "1": "minecraft:block/iron_block",
+      "particle": "minecraft:block/iron_block"
+	},
+	"elements": [
+		{
+			"from": [7, 0, 7],
+			"to": [9, 16, 9],
+			"faces": {
+				"north": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"down": {"uv": [0.032, 0.032, 1.968, 1.968], "texture": "#0", "cullface": "down"}
+			}
+		},
+		{
+			"from": [5, 16, 6],
+			"to": [9, 23, 10],
+			"rotation": {"angle": 0, "axis": "y", "origin": [7, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		},
+		{
+			"from": [3, 16, 5],
+			"to": [5, 23, 11],
+			"rotation": {"angle": 0, "axis": "y", "origin": [3, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		},
+		{
+			"from": [9, 16, 7],
+			"to": [13, 23, 9],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, 90, 0],
+			"translation": [0, 5.25, 1.25]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, 90, 0],
+			"translation": [0, 5.25, 1.25]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, 90, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, 90, 0]
+		},
+		"ground": {
+			"rotation": [90, 0, 77]
+		},
+		"gui": {
+			"rotation": [10, -35, 45],
+			"translation": [2, -3, 0],
+			"scale": [0.7, 0.7, 0.7]
+		},
+		"head": {
+			"translation": [0, 12.25, 0]
+		},
+		"fixed": {
+			"translation": [0, -3.25, 0]
+		}
+	}
+}

--- a/src/main/resources/assets/supermodreborn/models/item/netherite_staxeoverflow.json
+++ b/src/main/resources/assets/supermodreborn/models/item/netherite_staxeoverflow.json
@@ -1,0 +1,88 @@
+{
+	"credit": "Made with Blockbench",
+	"textures": {
+      "0": "minecraft:block/oak_log",
+      "1": "minecraft:block/netherite_block",
+      "particle": "minecraft:block/netherite_block"
+	},
+	"elements": [
+		{
+			"from": [7, 0, 7],
+			"to": [9, 16, 9],
+			"faces": {
+				"north": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"east": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"south": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 16], "texture": "#0"},
+				"down": {"uv": [0.032, 0.032, 1.968, 1.968], "texture": "#0", "cullface": "down"}
+			}
+		},
+		{
+			"from": [5, 16, 6],
+			"to": [9, 23, 10],
+			"rotation": {"angle": 0, "axis": "y", "origin": [7, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		},
+		{
+			"from": [3, 16, 5],
+			"to": [5, 23, 11],
+			"rotation": {"angle": 0, "axis": "y", "origin": [3, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"west": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		},
+		{
+			"from": [9, 16, 7],
+			"to": [13, 23, 9],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 0]},
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"east": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"south": {"uv": [0, 0, 16, 16], "texture": "#1"},
+				"up": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1", "cullface": "up"},
+				"down": {"uv": [0.032, 0.032, 15.968, 15.968], "texture": "#1"}
+			}
+		}
+	],
+	"display": {
+		"thirdperson_righthand": {
+			"rotation": [0, 90, 0],
+			"translation": [0, 5.25, 1.25]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [0, 90, 0],
+			"translation": [0, 5.25, 1.25]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, 90, 0]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, 90, 0]
+		},
+		"ground": {
+			"rotation": [90, 0, 77]
+		},
+		"gui": {
+			"rotation": [10, -35, 45],
+			"translation": [2, -3, 0],
+			"scale": [0.7, 0.7, 0.7]
+		},
+		"head": {
+			"translation": [0, 12.25, 0]
+		},
+		"fixed": {
+			"translation": [0, -3.25, 0]
+		}
+	}
+}


### PR DESCRIPTION
This pull request introduces a new set of custom axe items called "StAXEoverflow" for various materials (Iron, Diamond, Netherite, and Endium) with a special ability to break multiple logs at once, and adds their models and localization. It also corrects the attribute assignment for large shovel items.

**New Features:**

* Added new custom axe items: `IRON_STAXEOVERFLOW`, `DIAMOND_STAXEOVERFLOW`, `NETHERITE_STAXEOVERFLOW`, and `ENDIUM_STAXEOVERFLOW`, each registered in `ModItems` and made available in the creative inventory. These axes use a new class, `StAXEoverflow`, which enables breaking up to 128 connected log blocks at once unless the player is sneaking. [[1]](diffhunk://#diff-8cff295b9bdea5030697e60bf70683d94f45422c82e0ef7d691c8a7db2d1eed7R154-R172) [[2]](diffhunk://#diff-82f3b3c201189a103d86dd9c3416ae752a11b808414d84bdc117bfdf904afe7cR46-R49) [[3]](diffhunk://#diff-1c3b5f2b5b877e8fb028411d2a08490472399b6f858bb219074345f9d04e88b3R1-R79)
* Added English localization strings for the new StAXEoverflow items.
* Added block/item model JSON files for each new StAXEoverflow variant: `iron_staxeoverflow.json`, `diamond_staxeoverflow.json`, `netherite_staxeoverflow.json`, and `endium_staxeoverflow.json`. [[1]](diffhunk://#diff-ae942729c8ed1e62f6a97584c919e4b6a6161b975ca8afddc6ac44511079be86R1-R88) [[2]](diffhunk://#diff-1f6f2fc031b088c860e16491a862dca3c4411be8725b87bc14507bfa0bd7383bR1-R88) [[3]](diffhunk://#diff-7ee09ad04387adf856e18c7d5679351539f130b89cf55aae74ed574ed1cbe764R1-R88) [[4]](diffhunk://#diff-894a2c369f308d74573247f82d1859c9e6742716f9175a47a8c21a883b9678c2R1-R88)

**Bugfixes/Improvements:**

* Fixed the attributes for large shovel items to use `ShovelItem.createAttributes` instead of `PickaxeItem.createAttributes` for correct tool behavior.