### PR TITLE
Update StAXEoverflow.java

### DIFF
--- a/src/main/java/net/manufloso/item/custom/StAXEoverflow.java
+++ b/src/main/java/net/manufloso/item/custom/StAXEoverflow.java
@@ -14,6 +14,9 @@ import net.minecraft.world.level.block.state.BlockState;
 import java.util.*;
 
 public class StAXEoverflow extends AxeItem {
+    final int MAX_BLOCKS = 128;
+    final int HURT_PER_BLOCK = 1;
+
     public StAXEoverflow(Tier tier, Properties properties) {
         super(tier, properties);
     }
@@ -35,9 +38,8 @@ public class StAXEoverflow extends AxeItem {
         visited.add(startPos);
 
         int brokenBlocks = 0;
-        int limit = 128;
 
-        while (!queue.isEmpty() && brokenBlocks < limit) {
+        while (!queue.isEmpty() && brokenBlocks < MAX_BLOCKS) {
 
             BlockPos currentPos = queue.poll();
 
@@ -57,20 +59,20 @@ public class StAXEoverflow extends AxeItem {
                         if (neighborState.is(BlockTags.LOGS)) {
                             visited.add(neighborPos);
                             if (level.destroyBlock(neighborPos, true, player)) {
-                                stack.hurtAndBreak(1, player, EquipmentSlot.MAINHAND);
+                                stack.hurtAndBreak(HURT_PER_BLOCK, player, EquipmentSlot.MAINHAND);
                                 brokenBlocks++;
-                                if (brokenBlocks >= limit) {
+                                if (brokenBlocks >= MAX_BLOCKS) {
                                     break;
                                 }
                                 queue.add(neighborPos);
                             }
                         }
                     }
-                    if (brokenBlocks >= limit) {
+                    if (brokenBlocks >= MAX_BLOCKS) {
                         break;
                     }
                 }
-                if (brokenBlocks >= limit) {
+                if (brokenBlocks >= MAX_BLOCKS) {
                     break;
                 }
             }


### PR DESCRIPTION
This pull request refactors the `StAXEoverflow` class to improve maintainability by replacing magic numbers with named constants. The changes make it clearer what the block-breaking limit and damage per block are, and ensure these values are used consistently throughout the method.

**Refactoring and code clarity:**

* Introduced `MAX_BLOCKS` and `HURT_PER_BLOCK` constants to replace hard-coded values for block-breaking limit and damage per block in `StAXEoverflow` (`src/main/java/net/manufloso/item/custom/StAXEoverflow.java`).
* Updated the `breakSurroundingLogs` method to use `MAX_BLOCKS` and `HURT_PER_BLOCK` instead of magic numbers, ensuring consistency and improving code readability (`src/main/java/net/manufloso/item/custom/StAXEoverflow.java`). [[1]](diffhunk://#diff-1c3b5f2b5b877e8fb028411d2a08490472399b6f858bb219074345f9d04e88b3L38-R42) [[2]](diffhunk://#diff-1c3b5f2b5b877e8fb028411d2a08490472399b6f858bb219074345f9d04e88b3L60-R75)